### PR TITLE
docs: fix default port typo

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -76,7 +76,7 @@ It will not be able to do code execution and few other features requiring the Do
 
 ![VS Code debugging](res/dev/devinst-6.png)
 
-The framework will run at the default port 5000. If you open `http://localhost:5000` in your browser and see `ERR_EMPTY_RESPONSE`, don't panic, you may need to select another port like I did for some reason. If you need to change the defaut port, you can add `"--port=5555"` to the args in the `.vscode/launch.json` file or you can create a `.env` file in the root directory and set the `WEB_UI_PORT` variable to the desired port.
+The framework will run at the default port 5000. If you open `http://localhost:5000` in your browser and see `ERR_EMPTY_RESPONSE`, don't panic, you may need to select another port like I did for some reason. If you need to change the default port, you can add `"--port=5555"` to the args in the `.vscode/launch.json` file or you can create a `.env` file in the root directory and set the `WEB_UI_PORT` variable to the desired port.
 
 It may take a while the first time. You should see output like the screenshot below. The RFC error is ok for now as we did not yet connect our local development to another instance in docker.
 ![First run](res/dev/devinst-7.png)


### PR DESCRIPTION
## Summary
- fix misspelling of default port in development guide

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_b_6899f60314ec83248db2848590d6552d