### PR TITLE
Fix typo in job loop comment

### DIFF
--- a/python/helpers/job_loop.py
+++ b/python/helpers/job_loop.py
@@ -31,7 +31,7 @@ async def run_loop():
                 await scheduler_tick()
             except Exception as e:
                 PrintStyle().error(errors.format_error(e))
-        await asyncio.sleep(SLEEP_TIME)  # TODO! - if we lower it under 1min, it can run a 5min job multiple times in it's target minute
+        await asyncio.sleep(SLEEP_TIME)  # TODO! - if we lower it under 1min, it can run a 5min job multiple times in its target minute
 
 
 async def scheduler_tick():


### PR DESCRIPTION
## Summary
- fix typo in job loop comment to use possessive "its"

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'python`)

------
https://chatgpt.com/codex/tasks/task_b_6899f609ae2c8324b33e6ea417a31912