### PR TITLE
feat: improve tunnel handling

### DIFF
--- a/python/helpers/tunnel_manager.py
+++ b/python/helpers/tunnel_manager.py
@@ -1,5 +1,8 @@
 from flaredantic import FlareTunnel, FlareConfig, ServeoConfig, ServeoTunnel
 import threading
+import time
+from urllib.request import urlopen, Request
+from urllib.error import URLError
 
 
 # Singleton to manage the tunnel instance
@@ -19,6 +22,9 @@ class TunnelManager:
         self.tunnel_url = None
         self.is_running = False
         self.provider = None
+        self.port = None
+        self._start_event = threading.Event()
+        self._monitor_thread = None
 
     def start_tunnel(self, port=80, provider="serveo"):
         """Start a new tunnel or return the existing one's URL"""
@@ -26,16 +32,18 @@ class TunnelManager:
             return self.tunnel_url
 
         self.provider = provider
+        self.port = port
+        self._start_event = threading.Event()
 
         try:
             # Start tunnel in a separate thread to avoid blocking
             def run_tunnel():
                 try:
                     if self.provider == "cloudflared":
-                        config = FlareConfig(port=port, verbose=True)
+                        config = FlareConfig(port=self.port, verbose=True)
                         self.tunnel = FlareTunnel(config)
                     else:  # Default to serveo
-                        config = ServeoConfig(port=port) # type: ignore
+                        config = ServeoConfig(port=self.port)  # type: ignore
                         self.tunnel = ServeoTunnel(config)
 
                     self.tunnel.start()
@@ -43,19 +51,18 @@ class TunnelManager:
                     self.is_running = True
                 except Exception as e:
                     print(f"Error in tunnel thread: {str(e)}")
+                finally:
+                    self._start_event.set()
 
-            tunnel_thread = threading.Thread(target=run_tunnel)
-            tunnel_thread.daemon = True
+            tunnel_thread = threading.Thread(target=run_tunnel, daemon=True)
             tunnel_thread.start()
 
-            # Wait for tunnel to start (max 15 seconds instead of 5)
-            for _ in range(150):  # Increased from 50 to 150 iterations
-                if self.tunnel_url:
-                    break
-                import time
+            # Wait for tunnel to start (max 15 seconds)
+            started = self._start_event.wait(timeout=15)
+            if not started or not self.tunnel_url:
+                return None
 
-                time.sleep(0.1)
-
+            self._start_monitor()
             return self.tunnel_url
         except Exception as e:
             print(f"Error starting tunnel: {str(e)}")
@@ -69,6 +76,7 @@ class TunnelManager:
                 self.is_running = False
                 self.tunnel_url = None
                 self.provider = None
+                self.port = None
                 return True
             except Exception:
                 return False
@@ -77,3 +85,40 @@ class TunnelManager:
     def get_tunnel_url(self):
         """Get the current tunnel URL if available"""
         return self.tunnel_url if self.is_running else None
+
+    def _start_monitor(self):
+        if self._monitor_thread and self._monitor_thread.is_alive():
+            return
+
+        self._monitor_thread = threading.Thread(target=self._monitor_tunnel, daemon=True)
+        self._monitor_thread.start()
+
+    def _monitor_tunnel(self):
+        backoff = 1
+        while self.is_running:
+            if not self.tunnel_url:
+                time.sleep(backoff)
+                continue
+
+            try:
+                req = Request(self.tunnel_url, method="HEAD")
+                with urlopen(req, timeout=5):
+                    pass
+                backoff = 1
+            except URLError as e:
+                print(f"Tunnel ping failed: {e}")
+                if not self.is_running:
+                    break
+                time.sleep(backoff)
+                backoff = min(backoff * 2, 60)
+                try:
+                    self.stop_tunnel()
+                finally:
+                    # clear monitor reference and attempt restart
+                    self._monitor_thread = None
+                    self.start_tunnel(self.port or 80, self.provider or "serveo")
+                    return
+            except Exception as e:
+                print(f"Unexpected tunnel monitor error: {e}")
+
+            time.sleep(30)

--- a/run_tunnel.py
+++ b/run_tunnel.py
@@ -43,10 +43,15 @@ def run():
             request_handler=NoRequestLoggingWSGIRequestHandler,
             threaded=True,
         )
-        
+
         process.set_server(server)
         # server.log_startup()
-        server.serve_forever()
+        while True:
+            try:
+                server.serve_forever()
+                break
+            except OSError as e:
+                PrintStyle.error(f"Tunnel API socket error: {e}")
     finally:
         # Clean up tunnel if it was started
         if tunnel:


### PR DESCRIPTION
## Summary
- replace polling loop with event-driven tunnel start and background monitor
- add automatic reconnection with exponential backoff and keep-alive pings
- log socket errors in tunnel API and server without stopping service

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'python')*
- `PYTHONPATH=. pytest python/tests/test_task_plan.py -q`

------
https://chatgpt.com/codex/tasks/task_b_689a0e4441588324879f79b32ea3e020