### PR TITLE
feat: add self reflection and prompt optimization

### DIFF
--- a/python/extensions/response_stream/_30_self_reflection.py
+++ b/python/extensions/response_stream/_30_self_reflection.py
@@ -1,0 +1,16 @@
+from python.helpers.extension import Extension
+from python.helpers.self_reflection import SelfReflection
+from agent import LoopData
+
+
+class SelfReflectionExtension(Extension):
+
+    async def execute(
+        self,
+        loop_data: LoopData = LoopData(),
+        text: str = "",
+        parsed: dict = {},
+        **kwargs,
+    ):
+        if "tool_name" in parsed and parsed["tool_name"] == "response":
+            await SelfReflection.analyze(self.agent)

--- a/python/helpers/self_reflection.py
+++ b/python/helpers/self_reflection.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Dict
+
+from python.helpers.memory import Memory
+
+
+class SelfReflection:
+
+    def __init__(self, agent, interval: int = 3600) -> None:
+        self.agent = agent
+        self.interval = interval
+        self._task: asyncio.Task | None = None
+
+    async def start(self) -> None:
+        if self._task is None:
+            self._task = asyncio.create_task(self._run())
+
+    async def _run(self) -> None:
+        while True:
+            await asyncio.sleep(self.interval)
+            await SelfReflection.analyze(self.agent)
+
+    @staticmethod
+    async def analyze(agent, log_dir: str = "logs") -> Dict[str, int]:
+        base = Path(log_dir)
+        metrics = {"total_lines": 0, "error_lines": 0}
+        for file in base.glob("*.log"):
+            try:
+                with file.open() as f:
+                    for line in f:
+                        metrics["total_lines"] += 1
+                        if "error" in line.lower():
+                            metrics["error_lines"] += 1
+            except FileNotFoundError:
+                continue
+        db = await Memory.get(agent)
+        await db.insert_text(str(metrics), {"area": Memory.Area.MAIN.value, "tag": "self_reflection"})
+        return metrics

--- a/python/tools/prompt_optimizer.py
+++ b/python/tools/prompt_optimizer.py
@@ -1,0 +1,14 @@
+from python.helpers.tool import Tool, Response
+from python.helpers.call_llm import call_llm
+from python.helpers.memory import Memory
+
+
+class PromptOptimizer(Tool):
+
+    async def execute(self, prompt: str = "", **kwargs):
+        system = "You improve prompts for better LLM responses. Suggest alternative prompt variations."
+        model = self.agent.context.main_llm
+        suggestions = await call_llm(system, model, prompt)
+        db = await Memory.get(self.agent)
+        await db.insert_text(suggestions, {"area": Memory.Area.MAIN.value, "tag": "prompt_optimization", "original": prompt})
+        return Response(message=suggestions, break_loop=False)


### PR DESCRIPTION
## Summary
- analyze logs periodically and store performance metrics in memory
- add prompt optimizer tool that proposes prompt variations and logs history
- integrate self-reflection into response stream lifecycle

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'python')*


------
https://chatgpt.com/codex/tasks/task_b_689afd68491083249ac0623bde2d4dad