### PR TITLE
Add resource monitoring and scheduler integration

### DIFF
--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -1,0 +1,13 @@
+# Scheduler
+
+The scheduler executes background tasks defined by the agent. Before a task starts, the scheduler checks system resources using `python/helpers/resource_monitor.py`.
+
+Default limits can be adjusted in the module:
+
+```python
+DEFAULT_LIMITS = {"cpu": 90.0, "ram": 90.0, "gpu": 90.0}
+```
+
+If CPU, RAM or GPU usage exceeds these percentages, the task is postponed and retried on the next tick.
+
+Agents can request a snapshot of current usage via the `resource_report` tool.

--- a/python/helpers/resource_monitor.py
+++ b/python/helpers/resource_monitor.py
@@ -1,0 +1,56 @@
+import json
+import psutil
+import subprocess
+from typing import Dict
+
+
+def _gpu_usage() -> float:
+    """Return GPU memory utilisation percentage using nvidia-smi.
+    Returns 0.0 if GPU is not available or nvidia-smi is not installed."""
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=memory.used,memory.total",
+                "--format=csv,nounits,noheader",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        line = result.stdout.strip().split("\n")[0]
+        used, total = [float(x.strip()) for x in line.split(",")]
+        if total > 0:
+            return used / total * 100.0
+    except Exception:
+        pass
+    return 0.0
+
+
+def usage() -> Dict[str, float]:
+    """Return current resource usage percentages for CPU, RAM and GPU."""
+    cpu = psutil.cpu_percent(interval=None)
+    mem = psutil.virtual_memory().percent
+    gpu = _gpu_usage()
+    return {"cpu": cpu, "ram": mem, "gpu": gpu}
+
+
+DEFAULT_LIMITS: Dict[str, float] = {"cpu": 90.0, "ram": 90.0, "gpu": 90.0}
+
+
+def within_limits(limits: Dict[str, float] | None = None) -> bool:
+    """Check if current usage is below provided limits (in percent)."""
+    limits = limits or DEFAULT_LIMITS
+    current = usage()
+    for key, limit in limits.items():
+        if current.get(key, 0.0) > limit:
+            return False
+    return True
+
+
+def report(limits: Dict[str, float] | None = None) -> Dict[str, float]:
+    """Return a dict with current usage and limit information."""
+    limits = limits or DEFAULT_LIMITS
+    current = usage()
+    current.update({f"{k}_limit": v for k, v in limits.items()})
+    return current

--- a/python/helpers/task_scheduler.py
+++ b/python/helpers/task_scheduler.py
@@ -24,6 +24,7 @@ from python.helpers.files import get_abs_path, make_dirs, read_file, write_file
 from python.helpers.localization import Localization
 import pytz
 from typing import Annotated
+from python.helpers import resource_monitor
 
 SCHEDULER_FOLDER = "tmp/scheduler"
 
@@ -763,6 +764,11 @@ class TaskScheduler:
                 return
             if task_snapshot.state == TaskState.RUNNING:
                 self._printer.print(f"Scheduler Task '{task_snapshot.name}' already running, skipping")
+                return
+
+            if not resource_monitor.within_limits():
+                self._printer.print(
+                    f"Scheduler Task '{task_snapshot.name}' postponed: high system load")
                 return
 
             # Atomically fetch and check the task's current state

--- a/python/tests/test_resource_monitor.py
+++ b/python/tests/test_resource_monitor.py
@@ -1,0 +1,27 @@
+import types
+import python.helpers.resource_monitor as rm
+
+
+def _mock_psutil(monkeypatch, cpu, mem):
+    monkeypatch.setattr(rm.psutil, "cpu_percent", lambda interval=None: cpu)
+    memobj = types.SimpleNamespace(percent=mem)
+    monkeypatch.setattr(rm.psutil, "virtual_memory", lambda: memobj)
+
+
+def _mock_gpu(monkeypatch, used, total):
+    class Result:
+        stdout = f"{used},{total}\n"
+    monkeypatch.setattr(rm.subprocess, "run", lambda *a, **k: Result())
+
+
+def test_within_limits_low_load(monkeypatch):
+    _mock_psutil(monkeypatch, 10, 20)
+    _mock_gpu(monkeypatch, 1, 100)
+    assert rm.within_limits({"cpu": 50, "ram": 50, "gpu": 50})
+
+
+def test_within_limits_high_load(monkeypatch):
+    _mock_psutil(monkeypatch, 95, 96)
+    _mock_gpu(monkeypatch, 95, 100)
+    assert not rm.within_limits({"cpu": 50, "ram": 50, "gpu": 50})
+

--- a/python/tests/test_scheduler_resource.py
+++ b/python/tests/test_scheduler_resource.py
@@ -1,0 +1,94 @@
+import asyncio
+import sys
+import types
+import importlib
+
+# Stub heavy modules before importing TaskScheduler
+litellm_stub = types.ModuleType("litellm")
+litellm_stub.completion = None
+litellm_stub.acompletion = None
+litellm_stub.embedding = None
+sys.modules.setdefault("litellm", litellm_stub)
+
+dotenv_stub = types.ModuleType("dotenv")
+dotenv_stub.load_dotenv = lambda *a, **k: None
+sys.modules.setdefault("dotenv", dotenv_stub)
+
+agent_stub = types.ModuleType("agent")
+class _Dummy:
+    pass
+agent_stub.Agent = _Dummy
+agent_stub.AgentContext = _Dummy
+agent_stub.UserMessage = _Dummy
+sys.modules.setdefault("agent", agent_stub)
+
+initialize_stub = types.ModuleType("initialize")
+initialize_stub.initialize_agent = lambda *a, **k: None
+sys.modules.setdefault("initialize", initialize_stub)
+
+persist_chat_stub = types.ModuleType("python.helpers.persist_chat")
+persist_chat_stub.save_tmp_chat = lambda *a, **k: None
+sys.modules.setdefault("python.helpers.persist_chat", persist_chat_stub)
+
+print_style_stub = types.ModuleType("python.helpers.print_style")
+class PrintStyle:
+    def __init__(self, *a, **k): pass
+    def print(self, *a, **k): pass
+    def stream(self, *a, **k): pass
+print_style_stub.PrintStyle = PrintStyle
+sys.modules.setdefault("python.helpers.print_style", print_style_stub)
+
+defer_stub = types.ModuleType("python.helpers.defer")
+class DeferredTask:
+    def __init__(self, thread_name="Background"): pass
+    def start_task(self, func, *args, **kwargs):
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(func(*args, **kwargs))
+        loop.close()
+        return self
+    def kill(self, *a, **k): pass
+    def add_child_task(self, *a, **k): pass
+
+defer_stub.DeferredTask = DeferredTask
+sys.modules.setdefault("python.helpers.defer", defer_stub)
+
+files_stub = types.ModuleType("python.helpers.files")
+files_stub.get_abs_path = lambda *a, **k: ""
+files_stub.make_dirs = lambda *a, **k: None
+files_stub.read_file = lambda *a, **k: ""
+files_stub.write_file = lambda *a, **k: None
+sys.modules.setdefault("python.helpers.files", files_stub)
+
+localization_stub = types.ModuleType("python.helpers.localization")
+class Localization:
+    @staticmethod
+    def get():
+        class _Loc:
+            def get_timezone(self):
+                return "UTC"
+        return _Loc()
+localization_stub.Localization = Localization
+sys.modules.setdefault("python.helpers.localization", localization_stub)
+
+# Now import modules under test
+TS = importlib.import_module("python.helpers.task_scheduler")
+RM = importlib.import_module("python.helpers.resource_monitor")
+
+
+def test_task_postponed_on_high_load(monkeypatch):
+    monkeypatch.setattr(RM, "within_limits", lambda *a, **k: False)
+    scheduler = TS.TaskScheduler.get()
+    task = TS.AdHocTask.create(name="t", system_prompt="", prompt="", attachments=[], token="123")
+    scheduler._tasks.tasks.append(task)
+
+    run_called = False
+
+    async def on_run(self):
+        nonlocal run_called
+        run_called = True
+
+    monkeypatch.setattr(TS.AdHocTask, "on_run", on_run, raising=False)
+    asyncio.run(scheduler._run_task(task))
+
+    assert task.state == TS.TaskState.IDLE
+    assert run_called is False

--- a/python/tools/resource_report.py
+++ b/python/tools/resource_report.py
@@ -1,0 +1,10 @@
+import json
+from python.helpers.tool import Tool, Response
+from python.helpers import resource_monitor
+
+
+class ResourceReport(Tool):
+
+    async def execute(self, **kwargs):  # type: ignore[override]
+        data = resource_monitor.report()
+        return Response(message=json.dumps(data, indent=4), break_loop=False)


### PR DESCRIPTION
## Summary
- Monitor CPU, RAM, and GPU usage with a new `resource_monitor` helper
- Delay task execution when system load is high and expose usage via `resource_report` tool
- Document scheduler resource limits and add tests for resource-aware scheduling

## Testing
- `PYTHONPATH=. pytest python/tests/test_resource_monitor.py python/tests/test_scheduler_resource.py -q`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689afd9f69f88324a49276f10163f51c