### PR TITLE
feat: add history range and topic filters to message concatenation

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -568,9 +568,37 @@ class Agent:
         return self.hist_add_message(False, content=content)
 
     def concat_messages(
-        self, messages
-    ):  # TODO add param for message range, topic, history
-        return self.history.output_text(human_label="user", ai_label="assistant")
+        self,
+        start: int | None = None,
+        end: int | None = None,
+        topics: list[int] | None = None,
+    ):
+        """Return concatenated message history.
+
+        Parameters
+        ----------
+        start, end : int | None
+            Optional range of messages to include.
+        topics : list[int] | None
+            Optional list of topic indexes to include.
+
+        Returns
+        -------
+        str
+            Concatenated messages formatted with user/assistant labels.
+        """
+
+        extra: dict[str, Any] = {}
+        if start is not None:
+            extra["start"] = start
+        if end is not None:
+            extra["end"] = end
+        if topics is not None:
+            extra["topics"] = topics
+
+        return self.history.output_text(
+            human_label="user", ai_label="assistant", **extra
+        )
 
     def get_chat_model(self):
         return models.get_chat_model(

--- a/python/extensions/monologue_end/_50_memorize_fragments.py
+++ b/python/extensions/monologue_end/_50_memorize_fragments.py
@@ -36,7 +36,7 @@ class MemorizeMemories(Extension):
 
         # get system message and chat history for util llm
         system = self.agent.read_prompt("memory.memories_sum.sys.md")
-        msgs_text = self.agent.concat_messages(self.agent.history)
+        msgs_text = self.agent.concat_messages()
 
         # log query streamed by LLM
         async def log_callback(content):

--- a/python/extensions/monologue_end/_51_memorize_solutions.py
+++ b/python/extensions/monologue_end/_51_memorize_solutions.py
@@ -36,7 +36,7 @@ class MemorizeSolutions(Extension):
 
         # get system message and chat history for util llm
         system = self.agent.read_prompt("memory.solutions_sum.sys.md")
-        msgs_text = self.agent.concat_messages(self.agent.history)
+        msgs_text = self.agent.concat_messages()
 
         # log query streamed by LLM
         async def log_callback(content):


### PR DESCRIPTION
## Summary
- expand `Agent.concat_messages` to support `start`, `end`, and `topics` filters
- update memorize fragments/solutions extensions to use new concat API

## Testing
- `PYTHONPATH=/workspace/Agent-AES pytest`

------
https://chatgpt.com/codex/tasks/task_b_689b2b3e032c83248b7120421597922e