### PR TITLE
Validate MCP server type and document allowed options

### DIFF
--- a/docs/mcp_setup.md
+++ b/docs/mcp_setup.md
@@ -10,6 +10,16 @@ MCP servers are external processes or services that expose a set of tools that A
 2.  **Remote SSE Servers**: These are servers, often accessible over a network, that Agent Zero communicates with using Server-Sent Events (SSE), usually over HTTP/S.
 3.  **Remote Streaming HTTP Servers**: These are servers that use the streamable HTTP transport protocol for MCP communication, providing an alternative to SSE for network-based MCP servers.
 
+### Supported `type` values
+
+When defining a server in your configuration, the optional `"type"` field may be used to explicitly specify how Agent Zero should connect. The supported values are:
+
+- `"stdio"` for local stdio servers
+- `"sse"` for remote SSE servers
+- Streaming HTTP variants: `"http-stream"`, `"streaming-http"`, `"streamable-http"`, or `"http-streaming"`
+
+Any other value will cause Agent Zero to reject the configuration with an error.
+
 ## How Agent Zero Consumes MCP Tools
 
 Agent Zero discovers and integrates MCP tools dynamically:

--- a/python/helpers/mcp_handler.py
+++ b/python/helpers/mcp_handler.py
@@ -62,9 +62,10 @@ def _determine_server_type(config_dict: dict) -> str:
             return "MCPServerLocal"
         # For future types, we could add more cases here
         else:
-            # For unknown types, fall back to URL-based detection
-            # This allows for graceful handling of new types
-            pass
+            # For unknown types, raise an explicit error so callers can
+            # surface a clear message to users instead of silently
+            # defaulting to another server type.
+            raise ValueError(f"Unsupported server type: {server_type}")
 
     # Backward compatibility: if no type specified, use URL-based detection
     if "url" in config_dict or "serverUrl" in config_dict:
@@ -590,11 +591,22 @@ class MCPConfig(BaseModel):
                 continue
 
             try:
+                server_type = _determine_server_type(server_item)
                 # not generic MCPServer because: "Annotated can not be instatioated"
-                if server_item.get("url", None) or server_item.get("serverUrl", None):
+                if server_type == "MCPServerRemote":
                     self.servers.append(MCPServerRemote(server_item))
                 else:
                     self.servers.append(MCPServerLocal(server_item))
+            except ValueError as e:
+                error_msg = str(e)
+                (
+                    PrintStyle(
+                        background_color="grey", font_color="red", padding=True
+                    ).print(f"MCPConfig::__init__: {error_msg}")
+                )
+                self.disconnected_servers.append(
+                    {"config": server_item, "error": error_msg, "name": server_name}
+                )
             except Exception as e:
                 # log the error
                 error_msg = str(e)
@@ -605,7 +617,6 @@ class MCPConfig(BaseModel):
                         f"MCPConfig::__init__: Failed to create MCPServer '{server_name}': {error_msg}"
                     )
                 )
-                # add to failed servers
                 self.disconnected_servers.append(
                     {"config": server_item, "error": error_msg, "name": server_name}
                 )


### PR DESCRIPTION
## Summary
- Raise `ValueError` when an MCP server `type` is unrecognized
- Catch invalid server types during MCPConfig initialization and report a clear error
- Document supported `type` values in the MCP setup guide

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_689b2b43a5888324a4ff406c11c485f9