### PR TITLE
refactor: replace window.fetchApi with module imports

### DIFF
--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -273,3 +273,20 @@ In this example:
 - Leverage existing helpers rather than duplicating functionality
 - Test extensions thoroughly to ensure they don't interfere with core functionality
 - Document your extensions to make them easier to maintain and share
+
+## Web UI Integration
+Third-party extensions that add interface elements often need to call
+backend endpoints. The web UI exposes helper functions in
+`/js/api.js` that handle CSRF tokens and other details.
+
+```javascript
+import * as api from '/js/api.js';
+
+const response = await api.fetchApi('/my_endpoint', {
+  method: 'POST',
+  body: JSON.stringify({ foo: 'bar' })
+});
+```
+
+`window.fetchApi` is no longer available globally, so extensions must
+explicitly import the module to access these helpers.

--- a/webui/components/chat/speech/speech-store.js
+++ b/webui/components/chat/speech/speech-store.js
@@ -2,6 +2,7 @@ import { createStore } from "/js/AlpineStore.js";
 import { updateChatInput, sendMessage } from "/index.js";
 import { sleep } from "/js/sleep.js";
 import { store as microphoneSettingStore } from "/components/settings/speech/microphone-setting-store.js";
+import * as api from "/js/api.js";
 
 const Status = {
   INACTIVE: "inactive",
@@ -97,7 +98,7 @@ const model = {
   // Load settings from server
   async loadSettings() {
     try {
-      const response = await fetchApi("/settings_get", { method: "POST" });
+      const response = await api.fetchApi("/settings_get", { method: "POST" });
       const data = await response.json();
       const speechSection = data.settings.sections.find(
         (s) => s.title === "Speech"

--- a/webui/components/settings/backup/backup-store.js
+++ b/webui/components/settings/backup/backup-store.js
@@ -1,4 +1,5 @@
 import { createStore } from "/js/AlpineStore.js";
+import * as api from "/js/api.js";
 
 // Global function references
 const sendJsonData = window.sendJsonData;
@@ -397,7 +398,7 @@ const model = {
       const metadata = this.backupMetadataConfig;
 
       // Use fetch directly since backup_create returns a file download, not JSON
-      const response = await fetchApi('/backup_create', {
+      const response = await api.fetchApi('/backup_create', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -442,7 +443,7 @@ const model = {
 
   async downloadBackup(backupPath, backupName) {
     try {
-      const response = await fetchApi('/backup_download', {
+      const response = await api.fetchApi('/backup_download', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ backup_path: backupPath })
@@ -548,7 +549,7 @@ const model = {
       formData.append('overwrite_policy', this.overwritePolicy);
       formData.append('clean_before_restore', this.cleanBeforeRestore);
 
-      const response = await fetchApi('/backup_restore_preview', {
+      const response = await api.fetchApi('/backup_restore_preview', {
         method: 'POST',
         body: formData
       });
@@ -615,7 +616,7 @@ const model = {
       const formData = new FormData();
       formData.append('backup_file', file);
 
-      const response = await fetchApi('/backup_inspect', {
+      const response = await api.fetchApi('/backup_inspect', {
         method: 'POST',
         body: formData
       });
@@ -700,7 +701,7 @@ const model = {
       formData.append('overwrite_policy', this.overwritePolicy);
       formData.append('clean_before_restore', this.cleanBeforeRestore);
 
-      const response = await fetchApi('/backup_restore', {
+      const response = await api.fetchApi('/backup_restore', {
         method: 'POST',
         body: formData
       });

--- a/webui/index.js
+++ b/webui/index.js
@@ -5,8 +5,6 @@ import { sleep } from "/js/sleep.js";
 import { store as attachmentsStore } from "/components/chat/attachments/attachmentsStore.js";
 import { store as speechStore } from "/components/chat/speech/speech-store.js";
 
-window.fetchApi = api.fetchApi; // TODO - backward compatibility for non-modular scripts, remove once refactored to alpine
-
 const leftPanel = document.getElementById("left-panel");
 const rightPanel = document.getElementById("right-panel");
 const container = document.querySelector(".container");

--- a/webui/js/file_browser.js
+++ b/webui/js/file_browser.js
@@ -1,3 +1,5 @@
+import * as api from "/js/api.js";
+
 const fileBrowserModalProxy = {
   isOpen: false,
   isLoading: false,
@@ -39,7 +41,7 @@ const fileBrowserModalProxy = {
   async fetchFiles(path = "") {
     this.isLoading = true;
     try {
-      const response = await fetchApi(
+      const response = await api.fetchApi(
         `/get_work_dir_files?path=${encodeURIComponent(path)}`
       );
 
@@ -113,7 +115,7 @@ const fileBrowserModalProxy = {
     }
 
     try {
-      const response = await fetchApi("/delete_work_dir_file", {
+      const response = await api.fetchApi("/delete_work_dir_file", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -162,7 +164,7 @@ const fileBrowserModalProxy = {
       }
 
       // Proceed with upload after validation
-      const response = await fetchApi("/upload_work_dir_files", {
+      const response = await api.fetchApi("/upload_work_dir_files", {
         method: "POST",
         body: formData,
       });
@@ -199,7 +201,7 @@ const fileBrowserModalProxy = {
         file.path
       )}`;
 
-      const response = await fetchApi(downloadUrl);
+      const response = await api.fetchApi(downloadUrl);
 
       if (!response.ok) {
         throw new Error("Network response was not ok");

--- a/webui/js/scheduler.js
+++ b/webui/js/scheduler.js
@@ -5,6 +5,7 @@
 
 import { formatDateTime, getUserTimezone } from './time-utils.js';
 import { switchFromContext } from '../index.js';
+import * as api from './api.js';
 
 // Ensure the showToast function is available
 // if (typeof window.showToast !== 'function') {
@@ -256,7 +257,7 @@ const fullComponentImplementation = function() {
 
             this.isLoading = true;
             try {
-                const response = await fetchApi('/scheduler_tasks_list', {
+                const response = await api.fetchApi('/scheduler_tasks_list', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json'
@@ -784,7 +785,7 @@ const fullComponentImplementation = function() {
                 console.log('Final task data being sent to API:', JSON.stringify(taskData, null, 2));
 
                 // Make API request
-                const response = await fetchApi(apiEndpoint, {
+                const response = await api.fetchApi(apiEndpoint, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json'
@@ -874,7 +875,7 @@ const fullComponentImplementation = function() {
         // Run a task
         async runTask(taskId) {
             try {
-                const response = await fetchApi('/scheduler_task_run', {
+                const response = await api.fetchApi('/scheduler_task_run', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json'
@@ -918,7 +919,7 @@ const fullComponentImplementation = function() {
                 this.showLoadingState = true;
 
                 // Call API to update the task state
-                const response = await fetchApi('/scheduler_task_update', {
+                const response = await api.fetchApi('/scheduler_task_update', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json'
@@ -959,7 +960,7 @@ const fullComponentImplementation = function() {
                 // if we delete selected context, switch to another first
                 switchFromContext(taskId);
 
-                const response = await fetchApi('/scheduler_task_delete', {
+                const response = await api.fetchApi('/scheduler_task_delete', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json'

--- a/webui/js/settings.js
+++ b/webui/js/settings.js
@@ -1,4 +1,6 @@
 
+import * as api from "/js/api.js";
+
 const settingsModalProxy = {
     isOpen: false,
     settings: {},
@@ -363,7 +365,7 @@ document.addEventListener('alpine:init', function () {
             async fetchSettings() {
                 try {
                     this.isLoading = true;
-                    const response = await fetchApi('/api/settings_get', {
+                    const response = await api.fetchApi('/api/settings_get', {
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json'
@@ -436,7 +438,7 @@ document.addEventListener('alpine:init', function () {
                     }
 
                     // Send request
-                    const response = await fetchApi('/api/settings_save', {
+                    const response = await api.fetchApi('/api/settings_save', {
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json'
@@ -493,7 +495,7 @@ document.addEventListener('alpine:init', function () {
                     }
 
                     // Send test request
-                    const response = await fetchApi('/api/test_connection', {
+                    const response = await api.fetchApi('/api/test_connection', {
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json'

--- a/webui/js/tunnel.js
+++ b/webui/js/tunnel.js
@@ -1,4 +1,6 @@
 
+import * as api from "/js/api.js";
+
 // Tunnel settings for the Settings modal
 document.addEventListener('alpine:init', () => {
     Alpine.data('tunnelSettings', () => ({
@@ -13,7 +15,7 @@ document.addEventListener('alpine:init', () => {
 
         async checkTunnelStatus() {
             try {
-                const response = await fetchApi('/tunnel_proxy', {
+                const response = await api.fetchApi('/tunnel_proxy', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
@@ -36,7 +38,7 @@ document.addEventListener('alpine:init', () => {
                     
                     if (storedTunnelUrl) {
                         // Use the stored URL but verify it's still valid
-                        const verifyResponse = await fetchApi('/tunnel_proxy', {
+                        const verifyResponse = await api.fetchApi('/tunnel_proxy', {
                             method: 'POST',
                             headers: {
                                 'Content-Type': 'application/json',
@@ -83,7 +85,7 @@ document.addEventListener('alpine:init', () => {
                 
                 try {
                     // First stop any existing tunnel
-                    const stopResponse = await fetchApi('/tunnel_proxy', {
+                    const stopResponse = await api.fetchApi('/tunnel_proxy', {
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json',
@@ -117,7 +119,7 @@ document.addEventListener('alpine:init', () => {
         async generateLink() {
             // First check if authentication is enabled
             try {
-                const authCheckResponse = await fetchApi('/settings_get');
+                const authCheckResponse = await api.fetchApi('/settings_get');
                 const authData = await authCheckResponse.json();
                 
                 // Find the auth_login and auth_password in the settings
@@ -176,7 +178,7 @@ document.addEventListener('alpine:init', () => {
             
             try {
                 // Call the backend API to create a tunnel
-                const response = await fetchApi('/tunnel_proxy', {
+                const response = await api.fetchApi('/tunnel_proxy', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
@@ -208,7 +210,7 @@ document.addEventListener('alpine:init', () => {
                     
                     // Check if tunnel is running now
                     try {
-                        const statusResponse = await fetchApi('/tunnel_proxy', {
+                        const statusResponse = await api.fetchApi('/tunnel_proxy', {
                             method: 'POST',
                             headers: {
                                 'Content-Type': 'application/json',
@@ -260,7 +262,7 @@ document.addEventListener('alpine:init', () => {
                 
                 try {
                     // Call the backend to stop the tunnel
-                    const response = await fetchApi('/tunnel_proxy', {
+                    const response = await api.fetchApi('/tunnel_proxy', {
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- replace global `window.fetchApi` usage with `api.fetchApi` imports across webui scripts
- drop legacy `window.fetchApi` assignment in webui/index.js
- document how extensions can import `api.fetchApi`

## Testing
- `pytest` *(fails: No module named 'python')*

------
https://chatgpt.com/codex/tasks/task_b_689b2b44e4988324a209e60984b760c5