### PR TITLE
Fix UserMessage list default factories

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -236,8 +236,8 @@ class AgentConfig:
 @dataclass
 class UserMessage:
     message: str
-    attachments: list[str] = field(default_factory=list[str])
-    system_message: list[str] = field(default_factory=list[str])
+    attachments: list[str] = field(default_factory=list)
+    system_message: list[str] = field(default_factory=list)
 
 
 class LoopData:


### PR DESCRIPTION
## Summary
- replace typed list default factories in `UserMessage` with plain `list`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'python')*
- `python - <<'PY'
from agent import UserMessage
print('imported')
u = UserMessage(message='hello')
print(u)
PY`


------
https://chatgpt.com/codex/tasks/task_b_689b491e1a948324ad586c71b4cda54d