### PR TITLE
Log tool import errors

### DIFF
--- a/python/tools/unknown.py
+++ b/python/tools/unknown.py
@@ -6,6 +6,8 @@ from python.extensions.system_prompt._10_system_prompt import (
 
 class Unknown(Tool):
     async def execute(self, **kwargs):
+        if self.message:
+            return Response(message=self.message, break_loop=False)
         tools = get_tools_prompt(self.agent)
         return Response(
             message=self.agent.read_prompt(


### PR DESCRIPTION
## Summary
- log detailed errors when importing custom or default tools fails
- return descriptive messages via the Unknown tool

## Testing
- `pytest -p no:langsmith` *(fails: ModuleNotFoundError: No module named 'python')*

------
https://chatgpt.com/codex/tasks/task_b_689b4957b54c8324a93d34f1f7ce8eee