### PR TITLE
Use provided loop_data when building prompt

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -410,7 +410,7 @@ class Agent:
         await self.call_extensions("message_loop_prompts_before", loop_data=loop_data)
 
         # set system prompt and message history
-        loop_data.system = await self.get_system_prompt(self.loop_data)
+        loop_data.system = await self.get_system_prompt(loop_data)
         loop_data.history_output = self.history.output()
 
         # and allow extensions to edit them


### PR DESCRIPTION
## Summary
- use passed `loop_data` when building system prompt to avoid stale state

## Testing
- `pytest` *(fails: ImportError: cannot import name 'dotenv_values' from 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_689b49a5d7fc8324bccbacdce5a2af6f